### PR TITLE
add `@ok_to_fail` decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ venv.bak/
 .idea
 /.vagrant/
 .vscode
+tags

--- a/ducktape/mark/__init__.py
+++ b/ducktape/mark/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._mark import parametrize, matrix, defaults, ignore, parametrized, ignored, env, is_env  # NOQA
+from ._mark import parametrize, matrix, defaults, ignore, ok_to_fail, parametrized, ignored, oked_to_fail, env, is_env  # NOQA

--- a/ducktape/templates/report/report.css
+++ b/ducktape/templates/report/report.css
@@ -67,6 +67,14 @@ h1, h2, h3, h4, h5, h6 {
     background-color: #555;
 }
 
+.ofail {
+    background-color: #ffc;
+}
+
+.opass {
+    background-color: #9cf;
+}
+
 .testcase { 
     margin-left: 2em;
 }

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -11,6 +11,8 @@
     <div id="color_key_panel"></div>
     <div id="failed_test_panel"></div>
     <div id="ignored_test_panel"></div>
+    <div id="opassed_test_panel"></div>
+    <div id="ofailed_test_panel"></div>
     <div id="passed_test_panel"></div>
     <script type="text/jsx">
       /* This small block makes it possible to use React dev tools in the Chrome browser */
@@ -40,6 +42,8 @@
               <td colSpan='5' align='center'>{this.props.summary_prop.passes}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.failures}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.ignored}</td>
+              <td colSpan='5' align='center'>{this.props.summary_prop.opassed}</td>
+              <td colSpan='5' align='center'>{this.props.summary_prop.ofailed}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.run_time}</td>
             </tr>
           );
@@ -56,6 +60,8 @@
                   <th colSpan='5' align='center'>Passes</th>
                   <th colSpan='5' align='center'>Failures</th>
                   <th colSpan='5' align='center'>Ignored</th>
+                  <th colSpan='5' align='center'>OPassed</th>
+                  <th colSpan='5' align='center'>OFailed</th>
                   <th colSpan='5' align='center'>Time</th>
                 </tr>
               </thead>
@@ -177,6 +183,8 @@
         "passes": %(num_passes)d,
         "failures": %(num_failures)d,
         "ignored": %(num_ignored)d,
+        "opassed": %(num_opassed)d,
+        "ofailed": %(num_ofailed)d,
         "run_time": '%(run_time)s'
       }];
       
@@ -190,12 +198,16 @@
       PASSED_TESTS=[%(passed_tests)s];
       FAILED_TESTS=[%(failed_tests)s];
       IGNORED_TESTS=[%(ignored_tests)s];
+      OPASSED_TESTS=[%(opassed_tests)s];
+      OFAILED_TESTS=[%(ofailed_tests)s];
 
       React.render(<Heading heading={HEADING}/>, document.getElementById('heading'));
       React.render(<ColorKeyPanel test_status_names={COLOR_KEYS}/>, document.getElementById('color_key_panel'));
       React.render(<SummaryPanel summary_props={SUMMARY}/>, document.getElementById('summary_panel'));
       React.render(<TestPanel title="Failed Tests" tests={FAILED_TESTS}/>, document.getElementById('failed_test_panel'));
       React.render(<TestPanel title="Ignored Tests" tests={IGNORED_TESTS}/>, document.getElementById('ignored_test_panel'));
+      React.render(<TestPanel title="OPassed Tests" tests={OPASSED_TESTS}/>, document.getElementById('opassed_test_panel'));
+      React.render(<TestPanel title="OFailed Tests" tests={OFAILED_TESTS}/>, document.getElementById('ofailed_test_panel'));
       React.render(<TestPanel title="Passed Tests" tests={PASSED_TESTS}/>, document.getElementById('passed_test_panel'));
     </script>
   </body>

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -23,7 +23,7 @@ import pkg_resources
 
 from ducktape.utils.terminal_size import get_terminal_size
 from ducktape.utils.util import ducktape_version
-from ducktape.tests.status import PASS, FAIL, IGNORE
+from ducktape.tests.status import PASS, FAIL, IGNORE, OPASS, OFAIL
 from ducktape.json_serializable import DucktapeJSONEncoder
 
 
@@ -111,6 +111,8 @@ class SimpleSummaryReporter(SummaryReporter):
             "passed:           %d" % self.results.num_passed,
             "failed:           %d" % self.results.num_failed,
             "ignored:          %d" % self.results.num_ignored,
+            "opassed:          %d" % self.results.num_opassed,
+            "ofailed:          %d" % self.results.num_ofailed,
             "=" * self.width
         ]
 
@@ -122,15 +124,21 @@ class SimpleSummaryReporter(SummaryReporter):
         passed = []
         ignored = []
         failed = []
+        ofail = []
+        opass = []
         for result in self.results:
             if result.test_status == FAIL:
                 failed.append(result)
             elif result.test_status == IGNORE:
                 ignored.append(result)
+            elif result.test_status == OPASS:
+                opass.append(result)
+            elif result.test_status == OFAIL:
+                ofail.append(result)
             else:
                 passed.append(result)
 
-        ordered_results = passed + ignored + failed
+        ordered_results = passed + ignored + failed + opass + ofail
 
         report_lines = \
             [SingleResultReporter(result).result_string() + "\n" + "-" * self.width for result in ordered_results]
@@ -189,8 +197,13 @@ class JUnitReporter(object):
                 testsuite['failures'] += 1
             elif result.test_status == IGNORE:
                 testsuite['skipped'] += 1
+            elif result.test_status == OPASS:
+                testsuite['skipped'] += 1
+            elif result.test_status == OFAIL:
+                testsuite['skipped'] += 1
 
-        total = self.results.num_failed + self.results.num_ignored + self.results.num_passed
+        total = self.results.num_failed + self.results.num_ignored + self.results.num_ofailed + \
+            self.results.num_opassed + self.results.num_passed
         # Now start building XML document
         root = ET.Element('testsuites', attrib=dict(
             name="ducktape", time=str(self.results.run_time_seconds),
@@ -276,6 +289,8 @@ class HTMLSummaryReporter(SummaryReporter):
         failed_result_string = ""
         passed_result_string = ""
         ignored_result_string = ""
+        opassed_result_string = ""
+        ofailed_result_string = ""
 
         for result in self.results:
             json_string = json.dumps(self.format_result(result))
@@ -286,6 +301,12 @@ class HTMLSummaryReporter(SummaryReporter):
             elif result.test_status == FAIL:
                 failed_result_string += json_string
                 failed_result_string += ","
+            elif result.test_status == OPASS:
+                opassed_result_string += json_string
+                opassed_result_string += ","
+            elif result.test_status == OFAIL:
+                ofailed_result_string += json_string
+                ofailed_result_string += ","
             else:
                 ignored_result_string += json_string
                 ignored_result_string += ","
@@ -296,12 +317,16 @@ class HTMLSummaryReporter(SummaryReporter):
             'num_passes': self.results.num_passed,
             'num_failures': self.results.num_failed,
             'num_ignored': self.results.num_ignored,
+            'num_opassed': self.results.num_opassed,
+            'num_ofailed': self.results.num_ofailed,
             'run_time': format_time(self.results.run_time_seconds),
             'session': self.results.session_context.session_id,
             'passed_tests': passed_result_string,
             'failed_tests': failed_result_string,
             'ignored_tests': ignored_result_string,
-            'test_status_names': ",".join(["\'%s\'" % str(status) for status in [PASS, FAIL, IGNORE]])
+            'ofailed_tests': ofailed_result_string,
+            'opassed_tests': opassed_result_string,
+            'test_status_names': ",".join(["\'%s\'" % str(status) for status in [PASS, FAIL, IGNORE, OPASS, OFAIL]])
         }
 
         html = template % args

--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -21,7 +21,7 @@ from ducktape.json_serializable import DucktapeJSONEncoder
 from ducktape.tests.reporter import SingleResultFileReporter
 from ducktape.utils.local_filesystem_utils import mkdir_p
 from ducktape.utils.util import ducktape_version
-from ducktape.tests.status import PASS, FAIL, IGNORE
+from ducktape.tests.status import PASS, FAIL, IGNORE, OPASS, OFAIL
 
 
 class TestResult(object):
@@ -162,6 +162,14 @@ class TestResults(object):
         return len([r for r in self._results if r.test_status == IGNORE])
 
     @property
+    def num_opassed(self):
+        return len([r for r in self._results if r.test_status == OPASS])
+
+    @property
+    def num_ofailed(self):
+        return len([r for r in self._results if r.test_status == OFAIL])
+
+    @property
     def run_time_seconds(self):
         if self.start_time < 0:
             return -1
@@ -218,6 +226,8 @@ class TestResults(object):
             "num_passed": self.num_passed,
             "num_failed": self.num_failed,
             "num_ignored": self.num_ignored,
+            "num_opassed": self.num_opassed,
+            "num_ofailed": self.num_ofailed,
             "parallelism": parallelism,
             "results": [r for r in self._results]
         }

--- a/ducktape/tests/status.py
+++ b/ducktape/tests/status.py
@@ -30,3 +30,5 @@ class TestStatus(object):
 PASS = TestStatus("pass")
 FAIL = TestStatus("fail")
 IGNORE = TestStatus("ignore")
+OPASS = TestStatus("opass")
+OFAIL = TestStatus("ofail")

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -28,7 +28,7 @@ from ducktape.command_line.defaults import ConsoleDefaults
 from ducktape.services.service_registry import ServiceRegistry
 from ducktape.template import TemplateRenderer
 from ducktape.mark.resource import CLUSTER_SPEC_KEYWORD, CLUSTER_SIZE_KEYWORD
-from ducktape.tests.status import FAIL
+from ducktape.tests.status import FAIL, OFAIL
 
 
 class Test(TemplateRenderer):
@@ -151,7 +151,7 @@ class Test(TemplateRenderer):
                 # Gather locations of logs to collect
                 node_logs = []
                 for log_name in log_dirs.keys():
-                    if test_status == FAIL or self.should_collect_log(log_name, service):
+                    if test_status == FAIL or test_status == OFAIL or self.should_collect_log(log_name, service):
                         node_logs.append(log_dirs[log_name]["path"])
 
                 self.test_context.logger.debug("Preparing to copy logs from %s: %s" %
@@ -304,6 +304,7 @@ class TestContext(object):
         self.function = kwargs.get("function")
         self.injected_args = kwargs.get("injected_args")
         self.ignore = kwargs.get("ignore", False)
+        self.ok_to_fail = kwargs.get("ok_to_fail", False)
 
         # cluster_use_metadata is a dict containing information about how this test will use cluster resources
         self.cluster_use_metadata = copy.copy(kwargs.get("cluster_use_metadata", {}))
@@ -320,9 +321,9 @@ class TestContext(object):
     def __repr__(self):
         return \
             "<module=%s, cls=%s, function=%s, injected_args=%s, file=%s, ignore=%s, " \
-            "cluster_size=%s, cluster_spec=%s>" % \
+            "ok_to_fail=%s, cluster_size=%s, cluster_spec=%s>" % \
             (self.module, self.cls_name, self.function_name, str(self.injected_args), str(self.file),
-             str(self.ignore), str(self.expected_num_nodes), str(self.expected_cluster_spec))
+             str(self.ignore), str(self.ok_to_fail), str(self.expected_num_nodes), str(self.expected_cluster_spec))
 
     def copy(self, **kwargs):
         """Construct a new TestContext object from another TestContext object

--- a/tests/mark/check_ok_to_fail.py
+++ b/tests/mark/check_ok_to_fail.py
@@ -3,6 +3,7 @@ from ducktape.mark import ok_to_fail, oked_to_fail, parametrize, matrix
 
 import pytest
 
+
 class CheckOkToFail(object):
     def check_simple(self):
         @ok_to_fail

--- a/tests/mark/check_ok_to_fail.py
+++ b/tests/mark/check_ok_to_fail.py
@@ -1,0 +1,59 @@
+from ducktape.mark.mark_expander import MarkedFunctionExpander
+from ducktape.mark import ok_to_fail, oked_to_fail, parametrize, matrix
+
+import pytest
+
+class CheckOkToFail(object):
+    def check_simple(self):
+        @ok_to_fail
+        def function(x=1, y=2, z=3):
+            return x, y, z
+
+        assert oked_to_fail(function)
+        context_list = MarkedFunctionExpander(function=function).expand()
+        assert len(context_list) == 1
+        assert context_list[0].ok_to_fail
+
+    def check_simple_method(self):
+        class C(object):
+            @ok_to_fail
+            def function(self, x=1, y=2, z=3):
+                return x, y, z
+
+        assert oked_to_fail(C.function)
+        context_list = MarkedFunctionExpander(function=C.function, cls=C).expand()
+        assert len(context_list) == 1
+        assert context_list[0].ok_to_fail
+
+    def check_ok_to_fail_method(self):
+        """Check @ok_to_fail() with no arguments used with various parametrizations on a method."""
+        class C(object):
+            @ok_to_fail
+            @parametrize(x=100, y=200, z=300)
+            @parametrize(x=100, z=300)
+            @parametrize(y=200)
+            @matrix(x=[1, 2, 3])
+            @parametrize()
+            def function(self, x=1, y=2, z=3):
+                return x, y, z
+
+        assert oked_to_fail(C.function)
+        context_list = MarkedFunctionExpander(function=C.function, cls=C).expand()
+        assert len(context_list) == 7
+        for ctx in context_list:
+            assert ctx.ok_to_fail
+
+    def check_invalid_ok_to_fail(self):
+        """If there are no test cases to which ok_to_fail applies, it should raise an error"""
+        class C(object):
+            @parametrize(x=100, y=200, z=300)
+            @parametrize(x=100, z=300)
+            @parametrize(y=200)
+            @parametrize()
+            @ok_to_fail
+            def function(self, x=1, y=2, z=3):
+                return x, y, z
+
+        assert oked_to_fail(C.function)
+        with pytest.raises(AssertionError):
+            MarkedFunctionExpander(function=C.function, cls=C).expand()


### PR DESCRIPTION
This decorator was hinted at in upstream issue https://github.com/confluentinc/ducktape/issues/112

Adding the `@ok_to_fail` decorator to a test will still run the test, but the result will not be counted towards the final `PASS` or `FAIL` status. Instead, there will be 2 additional status results that are only used by tests decorated with `@ok_to_fail`: `OFAIL` and `OPASS`.

The `@ignore` decorator still behaves as usual by skipping the test.

You can decorate a ducktape test method with `@ok_to_fail` like so:
```
class DecoratorTests(Test):
    @ok_to_fail
    def test_failure(self):
        raise
    ...
```

And you should see test results that is formatted like so:
```
test_id:    rptest.tests.a_test.DecoratorTests.test_pass
status:     PASS
run time:   0.002 seconds
----------------------------------------------------------------------------------------------------
test_id:    rptest.tests.a_test.DecoratorTests.test_failure
status:     OFAIL
run time:   0.003 seconds
----------------------------------------------------------------------------------------------------
test_id:    rptest.tests.a_test.DecoratorTests.test_success
status:     OPASS
run time:   0.002 seconds
----------------------------------------------------------------------------------------------------
====================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2022-03-31--002
run time:         0.053 seconds
tests run:        3
passed:           1
failed:           0
ignored:          0
ofailed:          1
opassed:          1
====================================================================================================
```