### PR TITLE
add github workflow for python to run tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,16 @@
+name: Python
+on: [push]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py38


### PR DESCRIPTION
based on https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs-or-python?langId=py#running-tests-with-tox

runs the unit tests for python 3.8 https://ducktape.readthedocs.io/en/latest/misc.html?highlight=tox#unit-tests