### PR TITLE
Include summary in XML output for OFAIL tests

### DIFF
--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -226,7 +226,7 @@ class JUnitReporter(object):
                     name=name, classname=test.cls_name, time=str(test.run_time_seconds),
                     status=str(test.test_status), assertions=""
                 ))
-                if test.test_status == FAIL:
+                if test.test_status == FAIL or test.test_status == OFAIL:
                     xml_failure = ET.SubElement(xml_testcase, 'failure', attrib=dict(
                         message=test.summary.splitlines()[0]
                     ))


### PR DESCRIPTION
Previously this attribute was omitted for all but failures,
so on OFAIL we didn't get our one-line summary of a test's
failure reason (usually the exception).

Including this for OFAIL results makes it quicker to see what
went wrong.