### PR TITLE
Add debugging for hung tests

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -18,16 +18,21 @@ import importlib
 import json
 import os
 import random
+import signal
+from time import sleep
+from typing import Optional
 from six import iteritems
 import sys
 import traceback
 
 from ducktape.command_line.defaults import ConsoleDefaults
 from ducktape.command_line.parse_args import parse_args
+from ducktape.errors import TimeoutError
+from ducktape.tests.result import TestResults
 from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.loggermaker import close_logger
 from ducktape.tests.reporter import SimpleStdoutSummaryReporter, SimpleFileSummaryReporter, \
-    HTMLSummaryReporter, JSONReporter, JUnitReporter
+    HTMLSummaryReporter, JSONReporter, JUnitReporter, SummaryReporter
 from ducktape.tests.runner import TestRunner
 from ducktape.tests.session import SessionContext, SessionLoggerMaker
 from ducktape.tests.session import generate_session_id, generate_results_dir
@@ -172,22 +177,41 @@ def main():
 
     # Run the tests
     runner = TestRunner(cluster, session_context, session_logger, tests)
-    test_results = runner.run_all_tests()
+    test_results: Optional[TestResults] = None
+    try:
+        test_results = runner.run_all_tests()
+    except TimeoutError as e:
+        print(f"Timeout: assuming hung test.\n{e}")
+        for p in runner._client_procs.values():
+            assert p.pid != os.getpid(), "Main pid shouldn't be in client_procs"
+            if p.is_alive():
+                print(f"Hung test stacktrace: Sending SIGUSR1 to child pid {p.pid}")
+                os.kill(p.pid, signal.SIGUSR1)
+
+        sleep(0.2)  # wait for signal handlers to print, might not be necessary?
+        # try to force stuck clients to do cleanup and exit
+        for p in runner._client_procs.values():
+            if p.is_alive():
+                print(f"Sending SIGINT to child pid {p.pid}")
+                os.kill(p.pid, signal.SIGINT)
+                p.join()
 
     # Report results
-    reporters = [
-        SimpleStdoutSummaryReporter(test_results),
-        SimpleFileSummaryReporter(test_results),
-        HTMLSummaryReporter(test_results),
-        JSONReporter(test_results),
-        JUnitReporter(test_results)
-    ]
+    reporters: list[SummaryReporter] = []
+    if test_results:
+        reporters += [
+            SimpleStdoutSummaryReporter(test_results),
+            SimpleFileSummaryReporter(test_results),
+            HTMLSummaryReporter(test_results),
+            JSONReporter(test_results),
+            JUnitReporter(test_results)
+        ]
 
     for r in reporters:
         r.report()
 
     update_latest_symlink(args_dict["results_root"], results_dir)
     close_logger(session_logger)
-    if not test_results.get_aggregate_success():
+    if not (test_results and test_results.get_aggregate_success()):
         # Non-zero exit if at least one test failed
         sys.exit(1)

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -65,10 +65,12 @@ class Receiver(object):
             # use default value of 1800000 or 30 minutes
             timeout = 1800000
         self.socket.RCVTIMEO = timeout
+        t_0 = time.time()
         try:
             message = self.socket.recv()
         except zmq.Again:
-            raise TimeoutError("runner client unresponsive")
+            t_x = time.time()
+            raise TimeoutError(f"runner client unresponsive after {t_x - t_0:.2f} seconds.")
         return self.serde.deserialize(message)
 
     def send(self, event):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -37,6 +37,8 @@ from ducktape.errors import TimeoutError
 
 
 class Receiver(object):
+    LINGER_MS = 500
+
     def __init__(self, min_port, max_port):
         assert min_port <= max_port, "Expected min_port <= max_port, but instead: min_port: %s, max_port %s" % \
                                      (min_port, max_port)
@@ -48,6 +50,8 @@ class Receiver(object):
 
         self.zmq_context = zmq.Context()
         self.socket = self.zmq_context.socket(zmq.REP)
+        # Set a reasonable linger time to help with unclean shutdown
+        self.socket.setsockopt(zmq.LINGER, self.LINGER_MS)
 
     def start(self):
         """Bind to a random port in the range [self.min_port, self.max_port], inclusive
@@ -71,7 +75,6 @@ class Receiver(object):
         self.socket.send(self.serde.serialize(event))
 
     def close(self):
-        self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.close()
 
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -97,6 +97,7 @@ class TestRunner(object):
         # handler is inherited by all forked child processes, and it prevents the default python behavior
         # of translating SIGINT into a KeyboardInterrupt exception
         signal.signal(signal.SIGTERM, self._propagate_sigterm)
+        signal.signal(signal.SIGUSR1, self._propagate_sigusr1)
 
         # session_logger, message logger,
         self.session_logger = session_logger
@@ -123,6 +124,16 @@ class TestRunner(object):
         self._client_procs: dict[str, multiprocessing.Process] = {}
         self.active_tests = {}
         self.finished_tests = {}
+
+    def _propagate_sigusr1(self, signum, frame):
+        """ Propagate SIGUSR1 to all client processes. """
+        if os.getpid() != self.main_process_pid:
+            return
+
+        for p in self._client_procs.values():
+            assert p.pid != os.getpid(), "Signal handler unexpected in client subprocess."
+            if p.is_alive():
+                os.kill(p.pid, signal.SIGUSR1)
 
     def _propagate_sigterm(self, signum, frame):
         """Handler SIGTERM and SIGINT by propagating SIGTERM to all client processes.

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import faulthandler
 import logging
 import os
 import signal
@@ -43,6 +44,8 @@ class RunnerClient(object):
     def __init__(self, server_hostname, server_port, test_id,
                  test_index, logger_name, log_dir, debug, fail_bad_cluster_utilization):
         signal.signal(signal.SIGTERM, self._sigterm_handler)  # register a SIGTERM handler
+        # for debugging stuck processes
+        faulthandler.register(signal.SIGUSR1)
 
         self.serde = SerDe()
         self.logger = test_logger(logger_name, log_dir, debug)

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -281,7 +281,7 @@ class RunnerClient(object):
 
 
 class Sender(object):
-    REQUEST_TIMEOUT_MS = 3000
+    REQUEST_TIMEOUT_MS = 1000
     NUM_RETRIES = 5
 
     def __init__(self, server_host, server_port, message_supplier, logger):
@@ -298,6 +298,9 @@ class Sender(object):
 
     def _init_socket(self):
         self.socket = self.zmq_context.socket(zmq.REQ)
+        # Should be able to send immediately
+        self.socket.setsockopt(zmq.SNDTIMEO, self.REQUEST_TIMEOUT_MS)
+
         self.socket.connect(self.server_endpoint)
         self.poller.register(self.socket, zmq.POLLIN)
 

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -17,7 +17,9 @@ import os
 import signal
 import time
 import traceback
+from typing import Optional
 import zmq
+from zmq import Socket
 
 from six import iteritems
 
@@ -288,7 +290,7 @@ class Sender(object):
         self.serde = SerDe()
         self.server_endpoint = "tcp://%s:%s" % (str(server_host), str(server_port))
         self.zmq_context = zmq.Context()
-        self.socket = None
+        self.socket: Optional[Socket] = None
         self.poller = zmq.Poller()
 
         self.message_supplier = message_supplier


### PR DESCRIPTION
When debugging hard-to-reproduce "hung" test failures (like [redpanda #4634](https://github.com/redpanda-data/redpanda/issues/4634)), we ran into a couple of issues:

- Lack of any clues as to where the child test process is stuck.
- Ducktape processes failing to exit, and failing to gather any log output (related, IIUC).

The solution makes a couple of modifications:
- Adding debug signal handler to child processes, which will dump stack traces for all threads.
- Tolerating TimeoutError exceptions in main.py, as much as possible, to gather debug information and get all processes to exit.
- Tweaking some zmq socket-related parameters to try to avoid stuck sockets on unclean (i.e. passive side of connection) TCP shutdown.

Here is an example of the new ouptut you should see for a hanging test:
```
INFO:2022-06-10 20:52:07,852]: RunnerClient: rptest.tests.full_node_recovery_test.FullNodeRecoveryTest.test_hung_test: Running...                                                                                                    [36/455]
[ERROR:2022-06-10 20:52:22,861]: Exception receiving message: <class 'ducktape.errors.TimeoutError'>: runner client unresponsive after 15.01 seconds.
Timeout: assuming hung test.                                                                                           
runner client unresponsive after 15.01 seconds.                                                                        
Hung test stacktrace: Sending SIGUSR1 to child pid 13003                                                               
Thread 0x00007f1803fff640 (most recent call first):                                                                    
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/packet.py", line 301 in read_all                      
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/packet.py", line 459 in read_message                  
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/transport.py", line 2055 in run                       
  File "/usr/lib/python3.9/threading.py", line 973 in _bootstrap_inner                                                 
  File "/usr/lib/python3.9/threading.py", line 930 in _bootstrap                                                       
                                                                                                                       
Thread 0x00007f1810e67640 (most recent call first):                                                                    
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/packet.py", line 301 in read_all                      
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/packet.py", line 459 in read_message                  
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/transport.py", line 2055 in run                       
  File "/usr/lib/python3.9/threading.py", line 973 in _bootstrap_inner                                                 
  File "/usr/lib/python3.9/threading.py", line 930 in _bootstrap                                                       
                                                                                                                       
Thread 0x00007f1811668640 (most recent call first):        
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/packet.py", line 301 in read_all                      
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/packet.py", line 459 in read_message                  
  File "/home/ubuntu/.local/lib/python3.9/site-packages/paramiko/transport.py", line 2055 in run                       
  File "/usr/lib/python3.9/threading.py", line 973 in _bootstrap_inner                                                 
  File "/usr/lib/python3.9/threading.py", line 930 in _bootstrap                                                       
                                                                                                                       
Current thread 0x00007f181ad7afc0 (most recent call first):                                                            
  File "/home/ubuntu/redpanda/tests/rptest/tests/full_node_recovery_test.py", line 134 in _some_helper_func            
  File "/home/ubuntu/redpanda/tests/rptest/tests/full_node_recovery_test.py", line 143 in _some_func                   
  File "/home/ubuntu/redpanda/tests/rptest/tests/full_node_recovery_test.py", line 150 in test_hung_test               
  File "/home/ubuntu/redpanda/tests/rptest/services/cluster.py", line 35 in wrapped                                    
  File "/home/ubuntu/.local/lib/python3.9/site-packages/ducktape/tests/runner_client.py", line 233 in run_test         
  File "/home/ubuntu/.local/lib/python3.9/site-packages/ducktape/tests/runner_client.py", line 141 in run              
  File "/home/ubuntu/.local/lib/python3.9/site-packages/ducktape/tests/runner_client.py", line 39 in run_client        
  File "/usr/lib/python3.9/multiprocessing/process.py", line 108 in run                                                
  File "/usr/lib/python3.9/multiprocessing/process.py", line 315 in _bootstrap                                         
  File "/usr/lib/python3.9/multiprocessing/popen_fork.py", line 71 in _launch                                          
  File "/usr/lib/python3.9/multiprocessing/popen_fork.py", line 19 in __init__                                         
  File "/usr/lib/python3.9/multiprocessing/context.py", line 277 in _Popen                                             
  File "/usr/lib/python3.9/multiprocessing/context.py", line 224 in _Popen                                             
  File "/usr/lib/python3.9/multiprocessing/process.py", line 121 in start                                              
  File "/home/ubuntu/.local/lib/python3.9/site-packages/ducktape/tests/runner.py", line 264 in _run_single_test        
  File "/home/ubuntu/.local/lib/python3.9/site-packages/ducktape/tests/runner.py", line 214 in run_all_tests           
  File "/home/ubuntu/.local/lib/python3.9/site-packages/ducktape/command_line/main.py", line 182 in main               
  File "/home/ubuntu/.local/bin/ducktape", line 8 in <module>                                                          
Sending SIGINT to child pid 13003
```