### PR TITLE
updates for p 3.10

### DIFF
--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -35,7 +35,6 @@ class Cluster(object):
     This interface doesn't define any mapping of roles/services to nodes. It only interacts with some underlying
     system that can describe available resources and mediates reservations of those resources.
     """
-
     def __init__(self):
         self.max_used_nodes = 0
 
@@ -67,7 +66,7 @@ class Cluster(object):
 
     def free(self, nodes):
         """Free the given node or list of nodes"""
-        if isinstance(nodes, collections.Iterable):
+        if isinstance(nodes, collections.abc.Iterable):
             for s in nodes:
                 self.free_single(s)
         else:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name="ducktape",
                         'zipp<2.0.0',
                         'pywinrm==0.2.2',
                         'requests==2.24.0',
-                        'paramiko~=2.7.2',
+                        'paramiko~=2.11.0',
                         'pyzmq==19.0.2',
                         'pycryptodome==3.9.8',
                         # > 5.0 drops py27 support


### PR DESCRIPTION
From patch supplied by Michal Maslanka <michal@vectorized.io>

This PR updates paramiko from [2.7.2](https://github.com/paramiko/paramiko/releases/tag/2.7.2) to [2.11.0](https://github.com/paramiko/paramiko/releases/tag/2.11.0) so it can run on python 3.10.

Comparing changes: https://github.com/paramiko/paramiko/compare/2.7.2...2.11.0