### PR TITLE
relativize latest symlink

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -186,7 +186,9 @@ def main():
     for r in reporters:
         r.report()
 
-    update_latest_symlink(args_dict["results_root"], results_dir)
+    # Update the symlink to the session ID (i.e. the relativized path) rather
+    # than the full path to support bound volumes.
+    update_latest_symlink(args_dict["results_root"], session_id)
     close_logger(session_logger)
     if not test_results.get_aggregate_success():
         # Non-zero exit if at least one test failed


### PR DESCRIPTION
When running with dockerized ducktape, the 'latest' symlink generated
typically does not survive the journey across the bind mount. This
commit relativizes it since the symlink is always expected to be in the
results directory anyway.