### PR TITLE
Make wait_until faster by ignoring backoff_sec on success

### DIFF
--- a/ducktape/utils/util.py
+++ b/ducktape/utils/util.py
@@ -51,8 +51,7 @@ def wait_until(condition, timeout_sec, backoff_sec=.1, err_msg="", retry_on_exc=
             last_exception = e
             if not retry_on_exc:
                 raise e
-        finally:
-            time.sleep(backoff_sec)
+        time.sleep(backoff_sec)
 
     # it is safe to call Exception from None - will be just treated as a normal exception
     raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception


### PR DESCRIPTION
it isn't uncommon to have dozens of `wait_until` in a test. With `backoff_sec` set to 2 seconds 30 successful `wait_until` sums up to a minute of wasted CI time.