### PR TITLE
dt output: write raw results file

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -174,6 +174,12 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests)
     test_results = runner.run_all_tests()
 
+    if args_dict["raw_test_results"]:
+        print("Writing raw results file to %s." % args_dict["raw_test_results"])
+        with open(f"{args_dict['raw_test_results']}/raw_results.json", "w") as f:
+            f.write(str(test_results.to_json()))
+        f.close()
+
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -81,6 +81,8 @@ def create_ducktape_parser():
     parser.add_argument("--test-runner-timeout", action="store", type=int, default=1800000,
                         help="Amount of time in milliseconds between test communicating between the test runner"
                              " before a timeout error occurs. Default is 30 minutes")
+    parser.add_argument("--raw-test-results", action="store", type=str,
+                        help="Path to write raw results file")
     return parser
 
 

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -90,9 +90,10 @@ class SingleResultFileReporter(SingleResultReporter):
 
 
 class SummaryReporter(object):
-    def __init__(self, results):
+    def __init__(self, results, use_custom_test_log_path=False):
         self.results = results
         self.width = get_terminal_size()[0]
+        self.use_custom_test_log_path = use_custom_test_log_path
 
     def report(self):
         raise NotImplementedError("method report must be implemented by subclasses of SummaryReporter")
@@ -275,6 +276,8 @@ class HTMLSummaryReporter(SummaryReporter):
         Path is relative to the base results_dir. Relative path behaves better if the results directory is copied,
         moved etc.
         """
+        if self.use_custom_test_log_path:
+            return result.test_log_path
         base_dir = os.path.abspath(result.session_context.results_dir)
         base_dir = os.path.join(base_dir, "")  # Ensure trailing directory indicator
 

--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -145,6 +145,8 @@ class TestResult(object):
         self.nodes_allocated = obj["nodes_allocated"]
         self.nodes_used = obj["nodes_used"]
         self.services = obj["services"]
+        # custom
+        self.test_log_path = obj["test_log_path"] if "test_log_path" in obj else ""
         return self
 
 

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -49,6 +49,20 @@ class SessionContext(object):
     def to_json(self):
         return self.__dict__
 
+    def from_json(self, obj):
+        self.session_id = obj["session_id"]
+        self.results_dir = obj["results_dir"]
+        self.debug = obj["debug"]
+        self.compress = obj["compress"]
+        self.exit_first = obj["exit_first"]
+        self.no_teardown = obj["no_teardown"]
+        self.max_parallel = obj["max_parallel"]
+        self.default_expected_num_nodes = obj["default_expected_num_nodes"]
+        self.fail_bad_cluster_utilization = obj["fail_bad_cluster_utilization"]
+        self.test_runner_timeout = obj["test_runner_timeout"]
+        self._globals = obj["_globals"]
+        return self
+
 
 class SessionLoggerMaker(LoggerMaker):
     def __init__(self, session_context):


### PR DESCRIPTION
The motivation is that this file is the source
of truth of writing ducktape reports. This will
be used to combine multiple 'raw_results' files
in order to get a central one.

ref https://github.com/redpanda-data/devprod/issues/391