### PR TITLE
mark/matrix: forgive empty parametrization

### DIFF
--- a/ducktape/mark/_mark.py
+++ b/ducktape/mark/_mark.py
@@ -143,10 +143,15 @@ class Matrix(Mark):
         return "MATRIX"
 
     def apply(self, seed_context, context_list):
+        empty_parametrization = True
         for injected_args in cartesian_product_dict(self.injected_args):
+            empty_parametrization = False
             injected_fun = _inject(**injected_args)(seed_context.function)
             context_list.insert(0, seed_context.copy(function=injected_fun, injected_args=injected_args))
-
+        # forgive empty parametrization and mark test as IGNORE
+        if empty_parametrization and not context_list:
+            seed_context.ignore = True
+            context_list.insert(0, seed_context)
         return context_list
 
     def __eq__(self, other):


### PR DESCRIPTION
Currently, this is needed in the `cloud_storage_type` parametrization of one of our tests, that applies only on Azure. So, running on AWS, the `cloud_storage_type` is gonna be empty, but ducktape doesn't allow an empty list of any parameter in the `matrix` mark. This PR marks tests with such parametrization, as `ignore` in order for ducktape runner to not fail

ref redpanda-data/redpanda#8704