### PR TITLE
ducktape: Save command line on start and add it to HTML report

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -190,7 +190,7 @@ def main():
     deflake_num = max(1, deflake_num)
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
-
+    test_results.command_line = " ".join(sys.argv)
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -30,6 +30,7 @@
               </h1>
               <p>Test Session: {this.props.heading.session}</p>
               <p>Ducktape Version: {this.props.heading.ducktape_version}</p>
+              <p>Command line: {this.props.heading.command_line}</p>
             </div>
           );
         }
@@ -196,7 +197,8 @@
       
       HEADING={
         "ducktape_version": '%(ducktape_version)s',
-        "session": '%(session)s'
+        "session": '%(session)s',
+        "command_line": '%(command_line)s'
       };
 
       COLOR_KEYS=[%(test_status_names)s];

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -324,6 +324,7 @@ class HTMLSummaryReporter(SummaryReporter):
 
         args = {
             'ducktape_version': ducktape_version(),
+            'command_line': self.results.command_line,
             'num_tests': num_tests,
             'num_passes': self.results.num_passed,
             'num_flaky': self.results.num_flaky,

--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -136,7 +136,7 @@ class TestResults(object):
         self._results = []
         self.session_context = session_context
         self.cluster = cluster
-
+        self.command_line = ""
         # For tracking total run time
         self.start_time = -1
         self.stop_time = -1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pycryptodome==3.9.8
 more-itertools==5.0.0
 tox==3.20.0
 six==1.15.0
-PyYAML==6.0
+PyYAML==6.0.1


### PR DESCRIPTION
With minimal changes to structure and test flow, added command line as it was in `sys.argv`