### PR TITLE
CORE-14 Fixed ok-to-fail-fips to correctly return args

### DIFF
--- a/ducktape/mark/_mark.py
+++ b/ducktape/mark/_mark.py
@@ -503,12 +503,13 @@ def ok_to_fail_fips(*args, **kwargs):
 
         return False
 
-    if len(args) == 1 and len(kwargs) == 0 and running_fips():
+    if len(args) == 1 and len(kwargs) == 0:
         # this corresponds to the usage of the decorator with no arguments
         # @ok_to_fail_fips
         # def test_function:
         #  ...
-        Mark.mark(args[0], OkToFailFIPS())
+        if running_fips():
+            Mark.mark(args[0], OkToFailFIPS())
         return args[0]
 
 


### PR DESCRIPTION
Fixed issue with ok_to_fail_fips where tests marked this way would not run in non-FIPS mode.