### PR TITLE
setup: relax some of the version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ jinja2~=3.0.3
 boto3@ git+https://github.com/redpanda-data/boto3@5770b4da8f758ceaa47b6482a19569f29739704e
 # jinja2 pulls in MarkupSafe with a > constraint, but we need to constrain it for compatibility
 MarkupSafe~=2.0.0
-pyparsing<3.0.0
+pyparsing<=3.1.7
 zipp<2.0.0
 pywinrm==0.2.2
-requests==2.31.0
+requests>=2.20.0
 paramiko @ git+https://github.com/redpanda-data/paramiko@80de6f2f6657c901778a1ffe2213dbc31d7edc35
 pyzmq==19.0.2
 pycryptodome==3.9.8


### PR DESCRIPTION
In order to be able to use `pyiceberg` from ducktape tests we need to update some conflicting dependencies.
The conflicting dependencies were `requests` and `pyparsing`