### PR TITLE
Report all test executions when `--deflake N` is given

### DIFF
--- a/ducktape/tests/event.py
+++ b/ducktape/tests/event.py
@@ -26,9 +26,10 @@ class ClientEventFactory(object):
     TEARING_DOWN = "TEARING_DOWN"
     FINISHED = "FINISHED"
     LOG = "LOG"
+    ADD_RESULT = "ADD_RESULT"
 
     # Types of messages available
-    TYPES = {READY, SETTING_UP, RUNNING, TEARING_DOWN, FINISHED, LOG}
+    TYPES = {READY, SETTING_UP, RUNNING, TEARING_DOWN, FINISHED, LOG, ADD_RESULT}
 
     def __init__(self, test_id, test_index, source_id):
         self.test_id = test_id
@@ -112,6 +113,14 @@ class ClientEventFactory(object):
             }
         )
 
+    def add_result(self, result):
+        return self._event(
+            event_type=ClientEventFactory.ADD_RESULT,
+            payload={
+                "result": result
+            }
+        )
+
 
 class EventResponseFactory(object):
     """Used by the test runner to create responses to events from client processes."""
@@ -152,4 +161,7 @@ class EventResponseFactory(object):
         return self._event_response(client_event)
 
     def log(self, client_event):
+        return self._event_response(client_event)
+
+    def add_result(self, client_event):
         return self._event_response(client_event)

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -314,6 +314,8 @@ class TestRunner(object):
             self._handle_finished(event)
         elif event["event_type"] == ClientEventFactory.LOG:
             self._handle_log(event)
+        elif event["event_type"] == ClientEventFactory.ADD_RESULT:
+            self._handle_add_result(event)
         else:
             raise RuntimeError("Received event with unknown event type: " + str(event))
 
@@ -328,6 +330,11 @@ class TestRunner(object):
     def _handle_log(self, event):
         self.receiver.send(self.event_response.log(event))
         self._log(event["log_level"], event["message"])
+
+    def _handle_add_result(self, event):
+        self.receiver.send(self.event_response.add_result(event))
+        result = event['result']
+        self.results.append(result)
 
     def _handle_finished(self, event):
         test_key = TestKey(event["test_id"], event["test_index"])


### PR DESCRIPTION
Currently, when `--deflake` is used only the last result is present in the ducktape reports with `test_status` `FLAKY` in case 1/N passed. There is no indication of how many times the test was executed, how many times it failed and what was the stacktrace of each failure.

This PR adds all deflake executions in the ducktape reports, having `test_status` either `FAIL` (if 0/N passed) or `FLAKY` (if 1/N passed). Thus, we know how many times a test was executed and that if the status is `FLAKY`, it means 1 of them passed. The passed result should be the last one (per test_id) that has empty `summary`.

ref https://redpandadata.atlassian.net/browse/DEVPROD-2241