### PR TITLE
cluster/remoteaccount: log numeric IP of each account

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -190,7 +190,15 @@ class RemoteAccount(HttpMixin):
         client = SSHClient()
         client.set_missing_host_key_policy(IgnoreMissingHostKeyPolicy())
 
-        self._log(logging.DEBUG, "ssh_config: %s" % str(self.ssh_config))
+        try:
+            ip = socket.gethostbyname(self.externally_routable_ip)
+        except socket.gaierror as e:
+            ip = None
+            self._log(logging.WARN,
+                      f"error resolving {self.externally_routable_ip}: {e}")
+
+        self._log(logging.DEBUG,
+                  f"ssh_config: {self.ssh_config}, external IP: {ip}")
 
         client.connect(
             hostname=self.ssh_config.hostname,


### PR DESCRIPTION
https://github.com/redpanda-data/ducktape/pull/39 was merged into `0.11.x-redpanda`. I guess it is wrong and we need to target `0.12.x-redpanda` instead.