### PR TITLE
loader: Print exception stack trace on load error

### DIFF
--- a/ducktape/tests/loader.py
+++ b/ducktape/tests/loader.py
@@ -23,6 +23,7 @@ import itertools
 import os
 import re
 from typing import List
+import traceback
 
 import requests
 import yaml
@@ -287,6 +288,7 @@ class TestLoader(object):
                 self.logger.debug("Successfully imported " + module_name)
                 return module_and_file
             except Exception as e:
+                exc_info = sys.exc_info()
                 # Because of the way we are searching for
                 # valid modules in this loop, we expect some of the
                 # module names we construct to fail to import.
@@ -320,14 +322,15 @@ class TestLoader(object):
                             missing_module_pieces = missing_module.split(".")
                             expected_error = (missing_module_pieces == path_pieces[-len(missing_module_pieces):])
 
+                exception_message_with_traceback = ''.join(traceback.format_exception(*exc_info))
                 if expected_error:
                     self.logger.debug(
                         "Failed to import %s. This is likely an artifact of the "
-                        "ducktape module loading process: %s: %s", module_name, e.__class__.__name__, e)
+                        "ducktape module loading process: %s", module_name, exception_message_with_traceback)
                 else:
                     self.logger.error(
                         "Failed to import %s, which may indicate a "
-                        "broken test that cannot be loaded: %s: %s", module_name, e.__class__.__name__, e)
+                        "broken test that cannot be loaded: %s", module_name, exception_message_with_traceback)
             finally:
                 path_pieces = path_pieces[1:]
 


### PR DESCRIPTION
If a test is so broken that its python file fails to import ducktape cannot schedule a test run. In this case only the exception that prevented the import is printed. It is sometimes hard to debug without details such as line no or stack trace. This is to fix it.

Before:
```
[ERROR:2025-01-23 10:14:26,623]: Failed to import rptest.tests.node_restart_probe_test, which may indicate a broken test that cannot be loaded: ValueError: too many values to unpack (expected 2)
[WARNING:2025-01-23 10:14:26,624]: Didn't find any tests in /root/tests/rptest/tests/node_restart_probe_test.py 
```

After:
```
[ERROR:2025-01-23 11:15:15,040]: Failed to import rptest.tests.node_restart_probe_test, which may indicate a broken test that cannot be loaded: Traceback (most recent call last):
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/loader.py", line 287, in _import_module
    module_and_file = ModuleAndFile(module=importlib.import_module(module_name), file=file_path)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/tests/rptest/tests/node_restart_probe_test.py", line 38, in <module>
    Risks.EMPTY = Risks(**{typ: set() for typ in Risks.KEYS})  # type: ignore
  File "/root/tests/rptest/tests/node_restart_probe_test.py", line 28, in __init__
    self._risks = {k: set(v) for k, v in kvargs}
  File "/root/tests/rptest/tests/node_restart_probe_test.py", line 28, in <dictcomp>
    self._risks = {k: set(v) for k, v in kvargs}
ValueError: too many values to unpack (expected 2)

[WARNING:2025-01-23 11:01:02,204]: Didn't find any tests in /root/tests/rptest/tests/node_restart_probe_test.py 
```