### PR TITLE
runner_client: add ability to stop deflake on matched excluded exceptions

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -188,7 +188,8 @@ def main():
     if deflake_num < 1:
         session_logger.warning("specified number of deflake runs specified to be less than 1, running without deflake.")
     deflake_num = max(1, deflake_num)
-    runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
+    deflake_exclude_exceptions = args_dict['deflake_exclude_exceptions']
+    runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num, deflake_exclude_exceptions)
     test_results = runner.run_all_tests()
     test_results.command_line = " ".join(sys.argv)
     # Report results

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -100,6 +100,9 @@ def create_ducktape_parser():
                              "to determine flakyness. When not present, deflake will not be used, "
                              "and a test will be marked as either passed or failed. "
                              "When enabled tests will be marked as flaky if it passes on any of the reruns")
+    parser.add_argument("--deflake-exclude-exceptions", type=str, default="",
+                        help="comma separated exception names to exclude from deflake. "
+                             "applies when --deflake > 1")
     parser.add_argument("--allow-empty-tests-list", action="store_true",
                         default=os.environ.get("DUCKTAPE_ALLOW_EMPTY_TESTS_LIST", "0").lower() in ("1", "true", "yes"),
                         help="Proceeds without failing when no tests are loaded ")
@@ -207,4 +210,7 @@ def parse_args(args):
     if parsed_args_dict["version"]:
         print(ducktape_version())
         sys.exit(0)
+    # make list of deflake exclude exceptions
+    if parsed_args_dict["deflake_exclude_exceptions"]:
+        parsed_args_dict["deflake_exclude_exceptions"] = [d for d in str(parsed_args_dict["deflake_exclude_exceptions"]).split(",") if d]
     return parsed_args_dict

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -88,6 +88,7 @@ class TestRunner(object):
     stop_testing = False
 
     def __init__(self, cluster, session_context, session_logger, tests, deflake_num,
+                 deflake_exclude_exceptions=[],
                  min_port=ConsoleDefaults.TEST_DRIVER_MIN_PORT,
                  max_port=ConsoleDefaults.TEST_DRIVER_MAX_PORT,
                  finish_join_timeout=DEFAULT_MP_JOIN_TIMEOUT):
@@ -106,6 +107,7 @@ class TestRunner(object):
         self.receiver = Receiver(min_port, max_port)
 
         self.deflake_num = deflake_num
+        self.deflake_exclude_exceptions = deflake_exclude_exceptions
 
         self.session_context = session_context
         self.max_parallel = session_context.max_parallel
@@ -312,7 +314,8 @@ class TestRunner(object):
                 TestContext.results_dir(test_context, current_test_counter),
                 self.session_context.debug,
                 self.session_context.fail_bad_cluster_utilization,
-                self.deflake_num
+                self.deflake_num,
+                self.deflake_exclude_exceptions
             ])
 
         self._client_procs[test_key] = proc

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -133,6 +133,7 @@ class RunnerClient(object):
     # configs
     fail_bad_cluster_utilization: bool
     deflake_num: int
+    deflake_exlude_exceptions: List[str]|None
 
     def __init__(
         self,
@@ -144,7 +145,8 @@ class RunnerClient(object):
         log_dir: str,
         debug: bool,
         fail_bad_cluster_utilization: bool,
-        deflake_num: int
+        deflake_num: int,
+        deflake_exlude_exceptions: List[str]|None=None
     ):
         signal.signal(signal.SIGTERM, self._sigterm_handler)  # register a SIGTERM handler
 
@@ -160,6 +162,7 @@ class RunnerClient(object):
         self.sender = Sender(server_hostname, str(self.runner_port), self.message, self.logger)
 
         self.deflake_num = deflake_num
+        self.deflake_exlude_exceptions = deflake_exlude_exceptions
 
         # Wait to instantiate the test object until running the test
         self.test = None

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -162,6 +162,8 @@ class RunnerClient(object):
         self.sender = Sender(server_hostname, str(self.runner_port), self.message, self.logger)
 
         self.deflake_num = deflake_num
+        if deflake_exlude_exceptions is None:
+            deflake_exlude_exceptions = []
         self.deflake_exlude_exceptions = deflake_exlude_exceptions
 
         # Wait to instantiate the test object until running the test
@@ -172,6 +174,13 @@ class RunnerClient(object):
     @property
     def deflake_enabled(self) -> bool:
         return self.deflake_num > 1
+
+    def stop_deflake_retries(self, summary: str):
+        for e in self.deflake_exlude_exceptions:
+            # e.g. 'NodeCrash' or '<NodeCrash'
+            if summary.startswith(e) or summary.startswith(f"<{e}"):
+                return True
+        return False
 
     def ready(self):
         ready_reply = self.sender.send(self.message.ready())
@@ -239,6 +248,7 @@ class RunnerClient(object):
 
         try:
             while test_status == FAIL and num_runs < self.deflake_num:
+                stopped_deflake = False
                 num_runs += 1
                 self.log(logging.INFO, "on run {}/{}".format(num_runs, self.deflake_num))
                 start_time = time.time()
@@ -258,10 +268,15 @@ class RunnerClient(object):
                 if run_summary:
                     msg += ": {}".format("\n".join(run_summary))
                 self.log(logging.INFO, msg)
+                if test_status == FAIL and run_summary:
+                    if self.deflake_enabled and self.stop_deflake_retries("\n".join(run_summary)):
+                        self.log(logging.INFO, "exception matches deflake exclude exceptions. stopping deflake retries...")
+                        stopped_deflake = True
+                        break
 
         finally:
             stop_time = time.time()
-            summary = self.process_run_summaries(summaries, test_status)
+            summary = self.process_run_summaries(summaries, test_status, stopped_deflake)
             test_status, summary = self._check_cluster_utilization(test_status, summary)
             # convert summary from list to string
             summary = "\n".join(summary)
@@ -293,7 +308,7 @@ class RunnerClient(object):
             self.test_context = None
             self.test = None
 
-    def process_run_summaries(self, run_summaries: List[List[str]], test_status: TestStatus) -> List[str]:
+    def process_run_summaries(self, run_summaries: List[List[str]], test_status: TestStatus, stopped_deflake = False) -> List[str]:
         """
         Converts individual run summaries (there may be multiple if deflake is enabled)
         into a single run summary
@@ -303,6 +318,8 @@ class RunnerClient(object):
             return ["Test Passed"]
         # single run, can just return the summary
         if not self.deflake_enabled:
+            return run_summaries[0]
+        if stopped_deflake:
             return run_summaries[0]
 
         failure_summaries: Mapping[str: List[int]] = defaultdict(list)


### PR DESCRIPTION
When deflake is enabled (i.e. `--deflake N` where `N > 1`) ducktape automatically retries all failures regardless of the exception that was raised. Some exceptions should be blocked from being retried and marked as `FAIL`. This feature can be enabled by setting the new flag `--deflake-exclude-exceptions` that accepts a string with comma separated exception names on which the deflake mechanism should stop and treat it as a non-deflake failure

jira: [DEVPROD-2685]

[DEVPROD-2685]: https://redpandadata.atlassian.net/browse/DEVPROD-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ