### PR TITLE
[0.12.x-redpanda] gha: python.yml

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,14 @@
+name: python
+on: [push]
+jobs:
+  tox-py312:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'requirements-test.txt'
+      - run: pip install tox
+      - run: tox -e py312


### PR DESCRIPTION
jira: [DEVPROD-2745]

adds gha workflow to run python tests using `tox`

[DEVPROD-2745]: https://redpandadata.atlassian.net/browse/DEVPROD-2745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ