### PR TITLE
args: add flag to allow test failures

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -210,5 +210,7 @@ def main():
     update_latest_symlink(args_dict["results_root"], session_id)
     close_logger(session_logger)
     if not test_results.get_aggregate_success():
+        if args_dict['allow_test_failures']:
+            sys.exit(0)
         # Non-zero exit if at least one test failed
         sys.exit(1)

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -106,6 +106,9 @@ def create_ducktape_parser():
     parser.add_argument("--allow-empty-tests-list", action="store_true",
                         default=os.environ.get("DUCKTAPE_ALLOW_EMPTY_TESTS_LIST", "0").lower() in ("1", "true", "yes"),
                         help="Proceeds without failing when no tests are loaded ")
+    parser.add_argument("--allow-test-failures", action="store_true",
+                        default=False,
+                        help="Set this to force ducktape to not fail if there were test failures")
     return parser
 
 

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -133,7 +133,7 @@ class RunnerClient(object):
     # configs
     fail_bad_cluster_utilization: bool
     deflake_num: int
-    deflake_exlude_exceptions: List[str]|None
+    deflake_exlude_exceptions: List[str]
 
     def __init__(
         self,
@@ -146,7 +146,7 @@ class RunnerClient(object):
         debug: bool,
         fail_bad_cluster_utilization: bool,
         deflake_num: int,
-        deflake_exlude_exceptions: List[str]|None=None
+        deflake_exlude_exceptions: List[str]=None
     ):
         signal.signal(signal.SIGTERM, self._sigterm_handler)  # register a SIGTERM handler
 


### PR DESCRIPTION
this PR adds `--allow-test-failures` that exits gracefully in case there are ducktape test failures. CI currently is configured to allow **any** failure (not just test failures), and that leads to having to `grep` for errors. Instead with this we can only allow test failures which is fine given the analysis and retries CI does when running ducktape

jira: [DEVPROD-2592]

[DEVPROD-2592]: https://redpandadata.atlassian.net/browse/DEVPROD-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ