### PR TITLE
runner: handle timeout in client

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -260,7 +260,7 @@ class TestRunner(object):
 
                 if self._expect_client_requests:
                     try:
-                        event = self.receiver.recv(timeout=self.session_context.test_runner_timeout)
+                        event = self.receiver.recv(timeout=int(int(self.session_context.test_runner_timeout) * 1.2)) # test_runner_timeout is handled in the client. adding 20% seconds on top, to guard against client not being able to report to the server
                         self._handle(event)
                     except Exception as e:
                         err_str = "Exception receiving message: %s: %s, active_tests: \n %s \n" % (str(type(e)), str(e), self.active_tests_debug())
@@ -303,6 +303,10 @@ class TestRunner(object):
         self.active_tests[test_key] = True
         self.test_schedule_log.append(test_key)
 
+        test_runner_timeout = self.session_context.test_runner_timeout
+        if test_runner_timeout is None:
+            test_runner_timeout = 1800000
+
         proc = multiprocessing.Process(
             target=run_client,
             args=[
@@ -315,7 +319,8 @@ class TestRunner(object):
                 self.session_context.debug,
                 self.session_context.fail_bad_cluster_utilization,
                 self.deflake_num,
-                self.deflake_exclude_exceptions
+                test_runner_timeout,
+                self.deflake_exclude_exceptions,
             ])
 
         self._client_procs[test_key] = proc

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -113,6 +113,11 @@ class Sender(object):
         self.poller.unregister(self.socket)
 
 
+class TestTimeoutError(BaseException):
+    """Raised when a test fails to complete within the specified timeout period."""
+    pass
+
+
 class RunnerClient(object):
     """Run a single test"""
 
@@ -133,6 +138,7 @@ class RunnerClient(object):
     # configs
     fail_bad_cluster_utilization: bool
     deflake_num: int
+    test_runner_timeout: int
     deflake_exlude_exceptions: List[str]
 
     def __init__(
@@ -146,6 +152,7 @@ class RunnerClient(object):
         debug: bool,
         fail_bad_cluster_utilization: bool,
         deflake_num: int,
+        test_runner_timeout: int,
         deflake_exlude_exceptions: List[str]=None
     ):
         signal.signal(signal.SIGTERM, self._sigterm_handler)  # register a SIGTERM handler
@@ -162,6 +169,7 @@ class RunnerClient(object):
         self.sender = Sender(server_hostname, str(self.runner_port), self.message, self.logger)
 
         self.deflake_num = deflake_num
+        self.test_runner_timeout = test_runner_timeout
         if deflake_exlude_exceptions is None:
             deflake_exlude_exceptions = []
         self.deflake_exlude_exceptions = deflake_exlude_exceptions
@@ -370,7 +378,7 @@ class RunnerClient(object):
 
             # Run the test unit
             self.setup_test()
-            data = self.run_test()
+            data = self.run_test(self.test_runner_timeout)
             test_status = PASS
 
         except BaseException as e:
@@ -423,14 +431,31 @@ class RunnerClient(object):
         self.log(logging.INFO, "Setting up...")
         self.test.setup()
 
-    def run_test(self):
+    def run_test(self, test_runner_timeout):
         """Run the test!
 
         We expect test_context.function to be a function or unbound method which takes an
         instantiated test object as its argument.
         """
+        timeout_seconds = int(test_runner_timeout / 1000)
+
+        def _handle_timeout(signum, frame):
+            self.log(logging.WARN, f"Test execution exceeded the configured timeout limit '{timeout_seconds} sec'.")
+            raise TestTimeoutError(f"Test timed out after {timeout_seconds} seconds")
+
         self.log(logging.INFO, "Running...")
-        return self.test_context.function(self.test)
+
+        # Set up signal alarm
+        signal.signal(signal.SIGALRM, _handle_timeout)
+        signal.alarm(timeout_seconds)
+
+        try:
+            return self.test_context.function(self.test)
+        except TestTimeoutError as e:
+            self.log(logging.WARN, self._exc_msg(e))
+            raise
+        finally:
+            signal.alarm(0)  # cancel alarm
 
     def _exc_msg(self, e):
         return repr(e) + "\n" + traceback.format_exc(limit=16)


### PR DESCRIPTION
Ducktape sets up a server and uses multiprocessing to spawn a client. They communicate via TCP sockets, with the client sending events about the state of the running test. The --test-runner-timeout flag is an integer that defines the maximum time the client has to complete the test. If the server doesn't receive any event from the client within that time, it raises an exception (server-side), terminates all processes, and exits with code 1.

This behavior makes it difficult to diagnose test e.g. where the test was hanging before the socket timeout occurred. Additionally, such tests are not included in the generated reports.

This change moves the timeout logic to the client. The runner timeout is now passed to the client, which raises a TestTimeoutError if the test doesn't finish in time. It uses Linux signals to enforce the timeout, similar to how pytest-timeout handles test timeouts: https://github.com/pytest-dev/pytest-timeout/blob/2e96621ee1b61057438c0f8c5b158eddc31654c5/pytest_timeout.py#L304

If a timeout occurs, the client raises an exception just like a regular assertion error. This allows the test to be reported properly and avoids sudden termination of the test suite. Using signals also provides a full traceback, making it clear where the test was hanging when the timeout was triggered.

jira: [DEVPROD-3200]

[DEVPROD-3200]: https://redpandadata.atlassian.net/browse/DEVPROD-3200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ