### PR TITLE
Child process exit timeout tweaks [CORE-13453]

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -39,6 +39,10 @@ from ducktape.errors import TimeoutError
 
 DEFAULT_MP_JOIN_TIMEOUT = 30
 
+# Used in a log line to indicate issues are are potentially "corrupting" in the sense
+# that they may cause tests that have nothing to do with the original issue to fail.
+# After such an issues occurs, later test results should be treated with suspicion.
+CORRUPTING_FAILURE_TAG = "CORRUPTING_FAILURE"
 
 class Receiver(object):
     def __init__(self, min_port, max_port):
@@ -149,7 +153,8 @@ class TestRunner(object):
             # Note: This can lead to some tmp files being uncleaned, otherwise nothing else should be executed by the
             #       client after this point.
             self._log(logging.ERROR,
-                      f"after waiting {timeout}s, process {process.name} failed to complete.  Terminating...")
+                      f"{CORRUPTING_FAILURE_TAG} after waiting {timeout}s, process {process.name} failed "
+                      f"to complete (for test: {process_key}).  Terminating...")
             self._terminate_process(process)
             self.client_report[process_key]["status"] = "TERMINATED"
         process.join()

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -253,6 +253,7 @@ class RunnerClient(object):
 
         summaries = []
         num_runs = 0
+        internal_exception = None
 
         try:
             while test_status == FAIL and num_runs < self.deflake_num:
@@ -281,10 +282,15 @@ class RunnerClient(object):
                         self.log(logging.INFO, "exception matches deflake exclude exceptions. stopping deflake retries...")
                         stopped_deflake = True
                         break
-
+        except BaseException as e:
+            try:
+                internal_exception = str(e)
+            except Exception:
+                internal_exception = "unknown internal exception"
+            raise
         finally:
             stop_time = time.time()
-            summary = self.process_run_summaries(summaries, test_status, stopped_deflake)
+            summary = self.process_run_summaries(summaries, test_status, stopped_deflake, internal_exception)
             test_status, summary = self._check_cluster_utilization(test_status, summary)
             # convert summary from list to string
             summary = "\n".join(summary)
@@ -316,11 +322,17 @@ class RunnerClient(object):
             self.test_context = None
             self.test = None
 
-    def process_run_summaries(self, run_summaries: List[List[str]], test_status: TestStatus, stopped_deflake = False) -> List[str]:
+    def process_run_summaries(self, run_summaries: List[List[str]], test_status: TestStatus, stopped_deflake = False, internal_exception: str | None = None) -> List[str]:
         """
         Converts individual run summaries (there may be multiple if deflake is enabled)
         into a single run summary
         """
+
+        # internal exception case, i.e., runner_client threw in its own logic
+        # before/while/after running the test test, so return that
+        if internal_exception is not None:
+            return [f"INTERNAL EXCEPTION: {internal_exception}"]
+
         # no summary case, return test passed
         if not run_summaries:
             return ["Test Passed"]

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -267,7 +267,7 @@ class RunnerClient(object):
 
                 # dump threads after the test is complete;
                 # if any thread is not terminated correctly by the test we'll see it here
-                self.dump_threads(f"Threads after {self.test_id} finished")
+                self.dump_threads(f"Threads after {self.test_id} finished (any non-daemon threads may hang!)")
 
                 # if run passed, and not on the first run, the test is flaky
                 if test_status == PASS and num_runs > 1:
@@ -520,5 +520,5 @@ class RunnerClient(object):
         self.send(self.message.log(msg, level=log_level))
 
     def dump_threads(self, msg):
-        dump = '\n'.join([t.name for t in threading.enumerate()])
-        self.log(logging.DEBUG, f"{msg}: {dump}")
+        dump = '\n'.join([f"{t.name}: {t}" for t in threading.enumerate()])
+        self.log(logging.DEBUG, f"{msg}:\n{dump}")


### PR DESCRIPTION
Fixes related to https://redpandadata.atlassian.net/browse/CORE-13453:

 - Don't print "Test passed" in this case (or similar cases we have seen recently e.g., throwing `__str__` in Exception objects)
 - Indicate the seriousness about the corrupting failure in the log
 - Improved logging 