### PR TITLE
Fix runner tests broken by missing test_runner_timeout

### DIFF
--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -21,6 +21,9 @@ from ducktape.tests.loggermaker import LoggerMaker
 from ducktape.command_line.defaults import ConsoleDefaults
 
 
+DEFAULT_TEST_RUNNER_TIMEOUT_MS = 1800000  # 30 minutes
+
+
 class SessionContext(object):
     """Wrapper class for 'global' variables. A call to ducktape generates a single shared SessionContext object
     which helps route logging and reporting, etc.
@@ -39,7 +42,7 @@ class SessionContext(object):
         self.default_expected_num_nodes = kwargs.get("default_num_nodes", None)
         self.fail_bad_cluster_utilization = kwargs.get("fail_bad_cluster_utilization")
         self.fail_greedy_tests = kwargs.get("fail_greedy_tests", False)
-        self.test_runner_timeout = kwargs.get("test_runner_timeout")
+        self.test_runner_timeout = kwargs.get("test_runner_timeout", DEFAULT_TEST_RUNNER_TIMEOUT_MS)
         self._globals = kwargs.get("globals")
 
     @property

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -415,7 +415,7 @@ class CheckRunner(object):
         session_context = tests.ducktape_mock.session_context()
         test_context = tests.ducktape_mock.test_context(session_context=session_context)
         rc = RunnerClient(
-            "localhost", 22, test_context.test_id, 0, "dummy", "/tmp/dummy", True, False, 5
+            "localhost", 22, test_context.test_id, 0, "dummy", "/tmp/dummy", True, False, 5, 1800000
         )
         rc.sender = MockSender()
         rc.cluster = mock_cluster


### PR DESCRIPTION
## Summary

- `SessionContext.test_runner_timeout` defaulted to `None`, causing a `TypeError` in `run_all_tests()` when `recv()` tried `int(None)`. Default it to `1800000ms` (30 min) via a new `DEFAULT_TEST_RUNNER_TIMEOUT_MS` constant.
- `check_runner_client_report` test was missing the required `test_runner_timeout` positional arg to `RunnerClient`.

## Test plan

- [x] `pytest tests/runner/check_runner.py` — all 16 tests pass (previously only 1 passed)
- [x] `pytest tests/runner/check_sender_receiver.py` — both tests pass