### PR TITLE
runner: dump worker stacks on timeout via faulthandler

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -18,6 +18,7 @@ import logging
 import multiprocessing
 import os
 import signal
+import sys
 import time
 import traceback
 import zmq
@@ -271,6 +272,23 @@ class TestRunner(object):
                         err_str = "Exception receiving message: %s: %s, active_tests: \n %s \n" % (str(type(e)), str(e), self.active_tests_debug())
                         err_str += "\n" + traceback.format_exc(limit=16)
                         self._log(logging.ERROR, err_str)
+
+                        # Request stack traces from child processes before killing them.
+                        # Multiple samples help distinguish livelock from deadlock.
+                        max_workers = 3
+                        samples = 3
+                        procs_to_sample = list(self._client_procs.values())[:max_workers]
+                        self._log(logging.ERROR, "Requesting stack dumps from %d of %d worker(s)" %
+                                  (len(procs_to_sample), len(self._client_procs)))
+                        for proc in procs_to_sample:
+                            print("--- stack dump for worker pid %d ---" % proc.pid, file=sys.stderr, flush=True)
+                            for _ in range(samples):
+                                if proc.is_alive():
+                                    try:
+                                        os.kill(proc.pid, signal.SIGUSR1)
+                                    except OSError:
+                                        pass
+                                time.sleep(0.005)
 
                         # All processes are on the same machine, so treat communication failure as a fatal error
                         for proc in self._client_procs.values():

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+import faulthandler
 import logging
 import os
 import signal
@@ -37,6 +38,8 @@ from ducktape.utils.local_filesystem_utils import mkdir_p
 
 
 def run_client(*args, **kwargs):
+    # On timeout, the runner sends SIGUSR1 to dump all thread stacks to stderr
+    faulthandler.register(signal.SIGUSR1)
     client = RunnerClient(*args, **kwargs)
     client.ready()
     client.run()

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -36,6 +36,7 @@ from ducktape.errors import TimeoutError
 
 from unittest.mock import Mock, MagicMock
 import os
+import signal
 import xml.etree.ElementTree as ET
 
 from .resources.test_various_num_nodes import VariousNumNodesTest
@@ -266,6 +267,25 @@ class CheckRunner(object):
             runner.run_all_tests()
 
         assert not runner._client_procs
+
+    def check_runner_timeout_requests_stack_dumps(self, capfd):
+        """Check that SIGUSR1 is sent to child processes on timeout."""
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context(max_parallel=1000, test_runner_timeout=1)
+
+        test_methods = [TestThingy.test_delayed]
+        ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=TestThingy, test_methods=test_methods,
+                                   cluster=mock_cluster, session_context=session_context)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
+
+        with pytest.raises(TimeoutError), patch('os.kill', wraps=os.kill) as mock_kill:
+            runner.run_all_tests()
+
+        usr1_calls = [c for c in mock_kill.call_args_list if c.args[1] == signal.SIGUSR1]
+        assert len(usr1_calls) > 1
+
+        captured = capfd.readouterr()
+        assert "Current thread" in captured.err
 
     @pytest.mark.parametrize('fail_greedy_tests', [True, False])
     def check_fail_greedy_tests(self, fail_greedy_tests):


### PR DESCRIPTION
Worker processes already set a SIGALRM-based timeout that raises TestTimeoutError, which works when code is stuck in Python-level execution. However, when a child hangs in native code (C extensions, syscalls, GIL contention), the SIGALRM handler cannot fire because Python only dispatches signal handlers between bytecodes.

Register faulthandler on SIGUSR1 in worker processes. On runner timeout, send SIGUSR1 before terminating — faulthandler's C-level signal handler writes thread stacks directly to stderr, bypassing Python's signal dispatch, so it works even when the process is stuck in native code.